### PR TITLE
Significant digit fix

### DIFF
--- a/simpledonate.php
+++ b/simpledonate.php
@@ -174,6 +174,11 @@ function simpledonate_civicrm_pageRun(&$page) {
         }
         else {
           $priceFieldVal = civicrm_api3('PriceFieldValue', 'get', array('return' => "amount, title, name, is_default","price_field_id"=> $value['id'], 'is_active' => 1));
+          // Format the amount.
+          foreach ($priceFieldVal['values'] as $k => $dontCare) {
+            $amount = $priceFieldVal['values'][$k]['amount'];
+            $priceFieldVal['values'][$k]['amount'] = CRM_Utils_Money::format($amount, NULL, NULL, TRUE);
+          }
           $priceList = $priceFieldVal['values'];
           $htmlPriceList[$value['html_type']] = $priceFieldVal['values'];
         }

--- a/simpledonate.php
+++ b/simpledonate.php
@@ -178,6 +178,8 @@ function simpledonate_civicrm_pageRun(&$page) {
           foreach ($priceFieldVal['values'] as $k => $dontCare) {
             $amount = $priceFieldVal['values'][$k]['amount'];
             $priceFieldVal['values'][$k]['amount'] = CRM_Utils_Money::format($amount, NULL, NULL, TRUE);
+            $n = $priceFieldVal['values'][$k]['amount'];
+            $priceFieldVal['values'][$k]['amount'] = (floor($n) == round($n, 2)) ? number_format($n) : number_format($n, 2);
           }
           $priceList = $priceFieldVal['values'];
           $htmlPriceList[$value['html_type']] = $priceFieldVal['values'];


### PR DESCRIPTION
CiviCRM now stores 9 significant digits in the currency field, which means that Simple Donate displays amounts that look like: `$20.000000000`.

This PR does two things:
* Drops the numbers after the decimal point if the amount is a whole number (e.g. `$20`);
* If the amount is NOT a whole number, rounds to two significant digits (e.g. `$12.50`).