### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/SimpleDonate/Form/SimpleDonationSetting.php
+++ b/CRM/SimpleDonate/Form/SimpleDonationSetting.php
@@ -338,7 +338,7 @@ class CRM_SimpleDonate_Form_SimpleDonationSetting extends CRM_Admin_Form_Setting
       $result = civicrm_api3('Contribution', 'transact', $contributionparams);
     }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $error = $e->getMessage();
       $errorList['error'] = $error;
       return $errorList;


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.