### PR TITLE
Remove reference to deprecated CRM.resourceUrls

### DIFF
--- a/js/simpledonate.js
+++ b/js/simpledonate.js
@@ -1,15 +1,14 @@
 (function (angular, $, _) {
-  var resourceUrl = CRM.resourceUrls['com.webaccessglobal.simpledonate'];
   var simpleDonation = angular.module('simpledonate', ['ngRoute']);
   simpleDonation.config([
     '$routeProvider',
     function ($routeProvider) {
       $routeProvider.when('/donation/:id/', {
-        templateUrl: resourceUrl + '/partials/simpledonate.html',
+        templateUrl: '~/simpledonate/simpledonate.html',
         controller: 'SimpleDonationCtrl',
       });
       $routeProvider.when('/donation/:id/:thanks', {
-        templateUrl: resourceUrl + '/partials/thankYou.html',
+        templateUrl: '~/simpledonate/thankYou.html',
         controller: 'SimpleDonationCtrl'
       });
     }

--- a/simpledonate.php
+++ b/simpledonate.php
@@ -256,6 +256,7 @@ function simpledonate_civicrm_pageRun(&$page) {
 function simpledonate_civicrm_angularModules(&$angularModule) {
   $angularModule['simpledonate'] = array(
     'ext' => 'com.webaccessglobal.simpledonate',
+    'partials' => ['partials'],
     'js' => array(
       'js/simpledonate.js',
       'js/libs/parsley.min.js',


### PR DESCRIPTION
Variable is deprecated and soon to be removed.

Instead of downloading the partials via http, this uses the built-in loader from CiviCRM.

See https://github.com/civicrm/civicrm-core/pull/35234